### PR TITLE
fix: corrigindo retorno do campo salário líquido do endpoint contracheque

### DIFF
--- a/src/ExtratoSalarial.Core/Domain/UseCases/GetPaycheck/GetPaycheckByIdUseCase.cs
+++ b/src/ExtratoSalarial.Core/Domain/UseCases/GetPaycheck/GetPaycheckByIdUseCase.cs
@@ -36,7 +36,7 @@ namespace ExtratoSalarial.Core.Domain.UseCases.GetPaycheck
             var fgtsResult = new Fgts().Calculate(employee);
             var vtResult = new Vt().Calculate(employee);
 
-            var totalDeDescontos = -(inssResult + irResult + dentalInsuranceResult + healthInsuranceResult + fgtsResult + vtResult);
+            var totalDeDescontos = inssResult + irResult + dentalInsuranceResult + healthInsuranceResult + fgtsResult + vtResult;
             var salarioLiquidoResult = employee.SalarioBruto - totalDeDescontos;
 
             var entriesList = new List<EntriesData> {
@@ -54,7 +54,7 @@ namespace ExtratoSalarial.Core.Domain.UseCases.GetPaycheck
                 employee.Id,
                 employee.DataDeAdmissao.Month.ToString(),
                 employee.SalarioBruto,
-                totalDeDescontos,
+                -totalDeDescontos,
                 salarioLiquidoResult,
                 entriesList
             ); ;


### PR DESCRIPTION
- Corrigido o campo salário líquido do endpoint contracheque, dado o retorno ter utilizado a regra matemática : negativo com negativo igual a positivo.

**ANTES**
![image](https://github.com/juliavaz/extrato-salarial-api/assets/50247060/eeccb11d-0109-46e7-b61b-1b6d34615d41) 

**DEPOIS**
![image](https://github.com/juliavaz/extrato-salarial-api/assets/50247060/23b46b50-6572-4c4e-9964-c7d89a7c415a)
